### PR TITLE
Improve search functionality

### DIFF
--- a/lib/neoid.rb
+++ b/lib/neoid.rb
@@ -124,7 +124,7 @@ module Neoid
     end
 
     def search(types, term, options = {})
-      options = options.reverse_merge(limit: 15)
+      options = options.reverse_merge(limit: 15,match_type: "AND")
 
       types = [*types]
 
@@ -187,12 +187,11 @@ module Neoid
         return "" if term.nil? || term.empty?
 
         fulltext = fulltext ? "_fulltext" : nil
-        case match_type
-        when "OR"
-          "(" + term.split(/\s+/).reject(&:empty?).map{ |t| "#{field}#{fulltext}:#{sanitize_term(t)}" }.join(" OR ") + ")"
-        else
-          "(" + term.split(/\s+/).reject(&:empty?).map{ |t| "#{field}#{fulltext}:#{sanitize_term(t)}" }.join(" AND ") + ")"
-        end
+        valid_match_types = %w( AND OR )
+        match_type = valid_match_types.delete(match_type)
+        raise "Invalid match_type option. Valid values are #{valid_match_types.join(',')}" unless match_type
+
+        "(" + term.split(/\s+/).reject(&:empty?).map{ |t| "#{field}#{fulltext}:#{sanitize_term(t)}" }.join(" #{match_type} ") + ")"
       end
 
       def initialize_relationships

--- a/lib/neoid.rb
+++ b/lib/neoid.rb
@@ -139,7 +139,7 @@ module Neoid
         when String
           search_in_fields = type.neoid_config.search_options.fulltext_fields.keys
           next if search_in_fields.empty?
-          query_for_type << search_in_fields.map{ |field| generate_field_query(field, term, true) }.join(" OR ")
+          query_for_type << search_in_fields.map{ |field| generate_field_query(field, term, true, options[:match_type]) }.join(" OR ")
         when Hash
           term.each do |field, value|
             query_for_type << generate_field_query(field, value, false)
@@ -182,13 +182,17 @@ module Neoid
         query.gsub("'", "\\\\'")
       end
 
-      def generate_field_query(field, term, fulltext = false)
+      def generate_field_query(field, term, fulltext = false, match_type = "AND")
         term = term.to_s if term
         return "" if term.nil? || term.empty?
 
         fulltext = fulltext ? "_fulltext" : nil
-
-        "(" + term.split(/\s+/).reject(&:empty?).map{ |t| "#{field}#{fulltext}:#{sanitize_term(t)}" }.join(" AND ") + ")"
+        case match_type
+        when "OR"
+          "(" + term.split(/\s+/).reject(&:empty?).map{ |t| "#{field}#{fulltext}:#{sanitize_term(t)}" }.join(" OR ") + ")"
+        else
+          "(" + term.split(/\s+/).reject(&:empty?).map{ |t| "#{field}#{fulltext}:#{sanitize_term(t)}" }.join(" AND ") + ")"
+        end
       end
 
       def initialize_relationships

--- a/spec/neoid/search_spec.rb
+++ b/spec/neoid/search_spec.rb
@@ -87,5 +87,31 @@ describe Neoid::ModelAdditions do
         Neoid.search([Article], "manga").results.should =~ @articles
       end
     end
+
+    context "search matching types" do
+      before :each do
+        @articles = [
+          Article.create!(title: "Comics: How to draw manga", body: "Lorem ipsum dolor sit amet", year: 2012),
+          Article.create!(title: "Manga x", body: "Lorem ipsum dolor sit amet", year: 2012),
+          Article.create!(title: "hidden secrets of comics masters", body: "Lorem ipsum dolor sit amet", year: 2012),
+          Article.create!(title: "hidden secrets of manga comics artists", body: "Lorem ipsum dolor sit amet", year: 2012)
+        ]
+      end
+
+      it "should search return only matches with AND" do
+        Neoid.search([Article],"manga comics").results.size.should eq(1)
+
+        Neoid.search([Article],"manga comics",{match_type: "AND"}).results.size.should eq(1)
+      end
+
+      it "should search return all results with OR" do
+        Neoid.search([Article],"manga comics",{match_type: "OR"}).results.size.should eq(4)
+      end
+
+      it "should fail with wrong match_type" do
+        expect {Neoid.search([Article],"manga comics",{match_type: "MAYBE"})}.to raise_error("Invalid match_type option. Valid values are AND,OR")
+      end
+
+    end
   end
 end

--- a/spec/neoid/search_spec.rb
+++ b/spec/neoid/search_spec.rb
@@ -98,13 +98,13 @@ describe Neoid::ModelAdditions do
         ]
       end
 
-      it "should search return only matches with AND" do
+      it "should return search results only matches with AND" do
         Neoid.search([Article],"manga comics").results.size.should eq(1)
 
         Neoid.search([Article],"manga comics",{match_type: "AND"}).results.size.should eq(1)
       end
 
-      it "should search return all results with OR" do
+      it "should return search results all results with OR" do
         Neoid.search([Article],"manga comics",{match_type: "OR"}).results.size.should eq(4)
       end
 


### PR DESCRIPTION
Hi Elad,

I've added an option called [:match_type] to the Neoid.search method.
It allows the user in fulltext search to do an "OR" query between the words separated by spaces.
This allows the user to do queries such as:
Job.neo_search("java c#",:match_type => "OR") and get results that have either the words java or c# in them (or both).

On my DB, when doing:
Job.neo_search("java c#",:match_type => "OR") - I get a lot of results, and when doing the default behavior ("AND") - I get no results.

I think that this is a useful option.

Shai
