### PR TITLE
Fix broken testing link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,8 @@ In order to test your app or this gem, you need a running Neo4j database, dedica
 
 I use port 7574 for testing.
 
-To run another database locally (read [here](http://docs.neo4j.org/chunked/1.9.M03/server-installation.html#_multiple_server_instances_on_one_machine) too):
+To run another database locally (read
+[here](http://docs.neo4j.org/chunked/stable/ha-setup-tutorial.html#ha-local-cluster) too):
 
 Copy the entire Neo4j database folder to a different location,
 


### PR DESCRIPTION
Got a 404 on the previous link. This is from the most up-to-date docs.
