### PR TITLE
removed 'start_node = Neoid.db.get_root' in NeodatabaseCleaner

### DIFF
--- a/lib/neoid/database_cleaner.rb
+++ b/lib/neoid/database_cleaner.rb
@@ -1,6 +1,6 @@
 module Neoid
   class NeoDatabaseCleaner
-    def self.clean_db(start_node = Neoid.db.get_root)
+    def self.clean_db()
       Neoid.db.execute_script <<-GREMLIN
         g.V.toList().each { if (it.id != 0) g.removeVertex(it) }
         g.indices.each { g.dropIndex(it.indexName); }


### PR DESCRIPTION
Removed 'start_node = Neoid.db.get_root' in NeodatabaseCleaner because latest neography get_root function is broken, so clean_db is not working. Besides, NeodatabaseCleaner.clean_db() does not use start_node attribute
